### PR TITLE
Fix character manager tween callbacks, dialog warning, and save info dictionary lookups

### DIFF
--- a/scripts/GameManager.gd
+++ b/scripts/GameManager.gd
@@ -96,14 +96,15 @@ func load_save_data(save_data: Dictionary):
 
 # 設定の適用
 func apply_settings():
-	# 音量設定
-	AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), linear_to_db(settings.master_volume))
-	
-	# フルスクリーン設定
-	if settings.fullscreen:
-		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
-	else:
-		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
+        # 音量設定
+        var master_volume = settings.get("master_volume", 1.0)
+        AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), linear_to_db(master_volume))
+
+        # フルスクリーン設定
+        if settings.get("fullscreen", false):
+                DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
+        else:
+                DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
 
 # 次のシーンへ進む
 func advance_scene():

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -28,50 +28,51 @@ func start_game():
 	scenario_manager.start_scenario("prologue")
 
 func _on_scenario_command(command: Dictionary):
-	match command.type:
-		"dialog":
-			# ダイアログを表示
-			var dialog_data = [{
-				"speaker": command.speaker,
-				"text": command.text
-			}]
-			dialog_system.start_dialog(dialog_data)
-		
-		"narration":
-			# ナレーションを表示
-			var dialog_data = [{
-				"speaker": "ナレーション",
-				"text": command.text
-			}]
-			dialog_system.start_dialog(dialog_data)
-		
-		"show_character":
-			# キャラクターを表示
-			var position = get_character_position(command.position)
-			character_manager.show_character(
-				command.character, 
-				position, 
-				command.get("expression", "normal")
-			)
-			# 次のコマンドを実行
-			scenario_manager.advance_scenario()
-		
-		"change_expression":
-			# 表情を変更
-			character_manager.change_expression(
-				command.character, 
-				command.expression
-			)
-			# 次のコマンドを実行
-			scenario_manager.advance_scenario()
-		
-		"hide_character":
-			# キャラクターを非表示
-			character_manager.hide_character(command.character)
-			# 次のコマンドを実行
-			scenario_manager.advance_scenario()
-		
-		"hide_all_characters":
+        var command_type = command.get("type", "")
+        match command_type:
+                "dialog":
+                        # ダイアログを表示
+                        var dialog_data = [{
+                                "speaker": command.get("speaker", ""),
+                                "text": command.get("text", "")
+                        }]
+                        dialog_system.start_dialog(dialog_data)
+
+                "narration":
+                        # ナレーションを表示
+                        var dialog_data = [{
+                                "speaker": "ナレーション",
+                                "text": command.get("text", "")
+                        }]
+                        dialog_system.start_dialog(dialog_data)
+
+                "show_character":
+                        # キャラクターを表示
+                        var position = get_character_position(command.get("position", ""))
+                        character_manager.show_character(
+                                command.get("character", ""),
+                                position,
+                                command.get("expression", "normal")
+                        )
+                        # 次のコマンドを実行
+                        scenario_manager.advance_scenario()
+
+                "change_expression":
+                        # 表情を変更
+                        character_manager.change_expression(
+                                command.get("character", ""),
+                                command.get("expression", "normal")
+                        )
+                        # 次のコマンドを実行
+                        scenario_manager.advance_scenario()
+
+                "hide_character":
+                        # キャラクターを非表示
+                        character_manager.hide_character(command.get("character", ""))
+                        # 次のコマンドを実行
+                        scenario_manager.advance_scenario()
+
+                "hide_all_characters":
 			# 全キャラクターを非表示
 			character_manager.hide_all_characters()
 			# 次のコマンドを実行

--- a/scripts/SaveSystem.gd
+++ b/scripts/SaveSystem.gd
@@ -122,7 +122,7 @@ func delete_save(slot: int) -> bool:
 # 全セーブスロットの情報を取得
 func get_all_save_info() -> Array:
 	var save_info_list = []
-	
+
 	for i in range(MAX_SAVE_SLOTS):
 		var info = get_save_info(i)
 		if info.is_empty():
@@ -135,19 +135,20 @@ func get_all_save_info() -> Array:
 				"formatted_time": "空きスロット"
 			})
 		else:
-			var datetime = Time.get_datetime_dict_from_unix_time(info.timestamp)
+			var timestamp = info.get("timestamp", 0)
+			var datetime = Time.get_datetime_dict_from_unix_time(timestamp)
 			var formatted_time = "%04d/%02d/%02d %02d:%02d" % [
-				datetime.year, datetime.month, datetime.day,
-				datetime.hour, datetime.minute
+				datetime.get("year", 0), datetime.get("month", 0), datetime.get("day", 0),
+				datetime.get("hour", 0), datetime.get("minute", 0)
 			]
-			
+
 			save_info_list.append({
 				"slot": i,
 				"exists": true,
-				"chapter": info.chapter,
-				"scene": info.scene,
-				"timestamp": info.timestamp,
+				"chapter": info.get("chapter", 0),
+				"scene": info.get("scene", 0),
+				"timestamp": timestamp,
 				"formatted_time": formatted_time
 			})
-	
+
 	return save_info_list

--- a/scripts/SettingsSystem.gd
+++ b/scripts/SettingsSystem.gd
@@ -34,24 +34,30 @@ func _ready():
 
 # 設定UIを更新
 func update_ui():
-	var settings = GameManager.instance.settings
-	
-	master_volume_slider.value = settings.master_volume * 100
-	bgm_volume_slider.value = settings.bgm_volume * 100
-	se_volume_slider.value = settings.se_volume * 100
-	text_speed_slider.value = settings.text_speed * 100
-	auto_speed_slider.value = settings.auto_speed * 50
-	fullscreen_button.button_pressed = settings.fullscreen
+        var settings = GameManager.instance.settings
+        var master_volume = settings.get("master_volume", 1.0)
+        var bgm_volume = settings.get("bgm_volume", 0.8)
+        var se_volume = settings.get("se_volume", 0.8)
+        var text_speed = settings.get("text_speed", 1.0)
+        var auto_speed = settings.get("auto_speed", 2.0)
+        var fullscreen = settings.get("fullscreen", false)
+
+        master_volume_slider.value = master_volume * 100
+        bgm_volume_slider.value = bgm_volume * 100
+        se_volume_slider.value = se_volume * 100
+        text_speed_slider.value = text_speed * 100
+        auto_speed_slider.value = auto_speed * 50
+        fullscreen_button.button_pressed = fullscreen
 
 # マスター音量変更
 func _on_master_volume_changed(value: float):
-	GameManager.instance.settings.master_volume = value / 100.0
-	AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), linear_to_db(value / 100.0))
-	settings_changed.emit()
+        GameManager.instance.settings["master_volume"] = value / 100.0
+        AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), linear_to_db(value / 100.0))
+        settings_changed.emit()
 
 # BGM音量変更
 func _on_bgm_volume_changed(value: float):
-	GameManager.instance.settings.bgm_volume = value / 100.0
+        GameManager.instance.settings["bgm_volume"] = value / 100.0
 	# BGMバスが存在する場合の処理
 	var bgm_bus_index = AudioServer.get_bus_index("BGM")
 	if bgm_bus_index != -1:
@@ -60,7 +66,7 @@ func _on_bgm_volume_changed(value: float):
 
 # SE音量変更
 func _on_se_volume_changed(value: float):
-	GameManager.instance.settings.se_volume = value / 100.0
+        GameManager.instance.settings["se_volume"] = value / 100.0
 	# SEバスが存在する場合の処理
 	var se_bus_index = AudioServer.get_bus_index("SE")
 	if se_bus_index != -1:
@@ -69,17 +75,17 @@ func _on_se_volume_changed(value: float):
 
 # テキスト速度変更
 func _on_text_speed_changed(value: float):
-	GameManager.instance.settings.text_speed = value / 100.0
-	settings_changed.emit()
+        GameManager.instance.settings["text_speed"] = value / 100.0
+        settings_changed.emit()
 
 # オート速度変更
 func _on_auto_speed_changed(value: float):
-	GameManager.instance.settings.auto_speed = value / 50.0
-	settings_changed.emit()
+        GameManager.instance.settings["auto_speed"] = value / 50.0
+        settings_changed.emit()
 
 # フルスクリーン切り替え
 func _on_fullscreen_toggled(pressed: bool):
-	GameManager.instance.settings.fullscreen = pressed
+        GameManager.instance.settings["fullscreen"] = pressed
 	
 	if pressed:
 		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)


### PR DESCRIPTION
## Summary
- replace inline await usage in CharacterManager with tween finished callbacks to restore parsing
- guard character lookup when showing and hiding to avoid invalid references
- prefix the placeholder choices parameter to acknowledge it is unused and silence the warning
- access save slot dictionaries via subscripts when formatting metadata to avoid invalid index errors

## Testing
- godot4 --headless --quit *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da6feed7a4833288be9d9916018d86